### PR TITLE
Fix default user in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
     - docker
 
 before-install:
-    - docker build --build-arg USER=yi -t dev .
+    - docker build -t dev .
 
 deploy:
     provider: script


### PR DESCRIPTION
Use the default user name defined in Dockerfile when building a Docker image with Travis CI.

This PR is to clean up https://github.com/wangkuiyi/dockerize-devbox/pull/1.